### PR TITLE
`get_*_all` Verbesserungen - Breaking Changes!

### DIFF
--- a/lexoffice-php-api.php
+++ b/lexoffice-php-api.php
@@ -260,6 +260,10 @@ class lexoffice_client {
 		return $this->api_call('GET', 'order-confirmations', $uuid);
 	}
 
+	public function get_orderconfirmations_all() {
+	    return $this->get_vouchers('orderconfirmation');
+    }
+
 	/* legacy function - will be removed in futere releases */
 	/* use get_pdf($type, $uuid, $filename) instead */
 	public function get_invoice_pdf($uuid, $filename) {

--- a/lexoffice-php-api.php
+++ b/lexoffice-php-api.php
@@ -218,18 +218,7 @@ class lexoffice_client {
 	}
 
 	public function get_invoices_all() {
-		$result = $this->api_call('GET', 'voucherlist', '', '', '?page=0&size=100&sort=voucherNumber,DESC&voucherType=invoice,creditnote&voucherStatus=open,paid,paidoff,voided,transferred');
-		$vouchers = $result->content;
-		unset($result->content);
-
-		for ($i = 1; $i < $result->totalPages; $i++) {
-			$result_page = $this->api_call('GET', 'voucherlist', '', '', '?page='.$i.'&size=100&sort=voucherNumber,DESC&voucherType=invoice,creditnote&voucherStatus=open,paid,paidoff,voided,transferred');
-			foreach ($result_page->content as $voucher) {
-				$vouchers[] = $voucher;
-			}
-			unset($result_page->content);
-		}
-		return($vouchers);
+	    return $this->get_vouchers('invoice', 'open,paid,paidoff,voided,transferred');
 	}
 
 	public function get_last_invoices($count) {
@@ -371,6 +360,10 @@ class lexoffice_client {
 	public function get_creditnote($uuid) {
 		return $this->api_call('GET', 'credit-notes', $uuid);
 	}
+
+    public function get_creditnotes_all() {
+        return $this->get_vouchers('creditnote', 'open,paid,paidoff,voided,transferred');
+    }
 
 	public function update_contact($uuid, $data) {
 		return $this->api_call('PUT', 'contacts', $uuid, $data);


### PR DESCRIPTION
- `get_invoices_all` benutzt nun `get_vouchers`
- `get_invoices_all` gibt nun nurnoch Invoices aus, **keine Creditnotes zusätzlich**
- `get_creditnotes_all` hinzugefügt
- `get_orderconfirmations_all` hinzugefügt

improves #1